### PR TITLE
Clear state after handshake is complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 ## Usage
 ```js
-const Noise = require('basic-noise')
+const Noise = require('noise-handshake')
+const Cipher = require('noise-handshake/cipher')
 const initiator = new Noise('IK ', true)
 const responder = new Noise('IK', false)
 
@@ -22,10 +23,14 @@ initiator.recv(reply)
 
 console.log(initiator.handshakeComplete) // true
 
+// instantiate a cipher using shared secrets
+const send = new Cipher(initiator.rx)
+const recieve = new Cipher(initiator.tx)
+
 const msg = Buffer.from('hello, world')
 
-const enc = initiator.rx.encrypt(msg)
-console.log(responder.tx.decrypt(enc)) // hello, world
+const enc = send.encrypt(msg)
+console.log(recieve.decrypt(enc)) // hello, world
 ```
 
 ## API
@@ -66,10 +71,13 @@ Receive a handshake message from the peer and return the encrypted payload.
 
 `true` or `false`. Indicates whether `rx` and `tx` have been created yet.
 
-#### `const ciphertext = peer.rx.encrypt(plaintext, [ad])`
+When complete, the working handshake state shall be cleared *only* the following state shall remain on the object:
 
-Encrypt a message to the remote peer with an optional authenticated data passed in as `ad`.
-
-#### `const plaintext = peer.tx.decrypt(ciphertext, [ad])`
-
-Decrypt a ciphertext from the remote peer. Note `initiator.rx` is decrypted by `responder.tx` and vice versa. If the message was encrypted with authenticated data, this must be passed in as `ad` otherwise decryption shall fail
+```js
+{
+  tx, // session key to decrypt messages from remote peer
+  rx, // session key to encrypt messages to remote peer
+  remotePublicKey, // the remote peers public key,
+  handshakeHash, // a hash of the entire handshake state
+}
+```

--- a/cipher.js
+++ b/cipher.js
@@ -40,6 +40,12 @@ module.exports = class CipherState {
     return this.key !== null
   }
 
+  _clear () {
+    this.key.fill(0)
+    this.key = null
+    this.nonce = null
+  }
+
   static get MACBYTES () {
     return 16
   }

--- a/dh.js
+++ b/dh.js
@@ -1,5 +1,5 @@
 /* eslint-disable camelcase */
-const { crypto_kx_SEEDBYTES, crypto_kx_keypair } = require('sodium-universal/crypto_kx')
+const { crypto_kx_SEEDBYTES, crypto_kx_keypair, crypto_kx_seed_keypair } = require('sodium-universal/crypto_kx')
 const { crypto_scalarmult_BYTES, crypto_scalarmult_SCALARBYTES, crypto_scalarmult, crypto_scalarmult_base } = require('sodium-universal/crypto_scalarmult')
 
 const assert = require('nanoassert')
@@ -17,6 +17,7 @@ module.exports = {
   SEEDLEN,
   ALG,
   generateKeyPair,
+  generateSeedKeyPair,
   dh
 }
 
@@ -32,6 +33,17 @@ function generateKeyPair (privKey) {
     crypto_kx_keypair(keyPair.publicKey, keyPair.secretKey)
   }
 
+  return keyPair
+}
+
+function generateSeedKeyPair (seed) {
+  assert(seed.byteLength === SKLEN)
+
+  const keyPair = {}
+  keyPair.secretKey = Buffer.alloc(SKLEN)
+  keyPair.publicKey = Buffer.alloc(PKLEN)
+
+  crypto_kx_seed_keypair(keyPair.publicKey, keyPair.secretKey, seed)
   return keyPair
 }
 

--- a/noise.js
+++ b/noise.js
@@ -92,6 +92,7 @@ module.exports = class NoiseState extends SymmetricState {
 
     this.rx = null
     this.tx = null
+    this.handshakeHash = null
   }
 
   initialise (prologue, remoteStatic) {
@@ -124,12 +125,15 @@ module.exports = class NoiseState extends SymmetricState {
   }
 
   final () {
-    const { cipher1, cipher2 } = this.split()
+    const [k1, k2] = this.split()
 
-    this.tx = this.initiator ? cipher1 : cipher2
-    this.rx = this.initiator ? cipher2 : cipher1
+    this.tx = this.initiator ? k1 : k2
+    this.rx = this.initiator ? k2 : k1
 
     this.handshakeComplete = true
+    this.handshakeHash = this.getHandshakeHash()
+
+    // this._clear()
   }
 
   recv (buf) {
@@ -209,6 +213,18 @@ module.exports = class NoiseState extends SymmetricState {
 
     if (!this.handshake.length) this.final()
     return w.end()
+  }
+
+  _clear () {
+    super._clear()
+
+    this.e.secretKey.fill(0)
+    this.re.fill(0)
+    this.rs.fill(0)
+
+    this.e.secretKey = null
+    this.re = null
+    this.rs = null
   }
 }
 

--- a/noise.js
+++ b/noise.js
@@ -133,7 +133,9 @@ module.exports = class NoiseState extends SymmetricState {
     this.handshakeComplete = true
     this.handshakeHash = this.getHandshakeHash()
 
-    // this._clear()
+    this.remotePublicKey = new Uint8Array(this.rs)
+
+    this._clear()
   }
 
   recv (buf) {
@@ -210,19 +212,22 @@ module.exports = class NoiseState extends SymmetricState {
     }
 
     w.push(this.encryptAndHash(payload))
+    const response = w.end()
 
     if (!this.handshake.length) this.final()
-    return w.end()
+    return response
   }
 
   _clear () {
     super._clear()
 
     this.e.secretKey.fill(0)
+    this.e.publicKey.fill(0)
+
     this.re.fill(0)
     this.rs.fill(0)
 
-    this.e.secretKey = null
+    this.e = null
     this.re = null
     this.rs = null
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noise-handshake",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "",
   "main": "noise.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "noise-handshake",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "",
   "main": "noise.js",
   "scripts": {

--- a/symmetric-state.js
+++ b/symmetric-state.js
@@ -48,12 +48,21 @@ module.exports = class SymmetricState extends CipherState {
   }
 
   split () {
-    const [k1, k2] = hkdf(this.chainingKey, Buffer.alloc(0))
+    const res = hkdf(this.chainingKey, Buffer.alloc(0))
+    return res.map(k => k.subarray(0, 32))
+  }
 
-    return {
-      cipher1: new CipherState(k1.subarray(0, 32)),
-      cipher2: new CipherState(k2.subarray(0, 32))
-    }
+  _clear () {
+    super._clear()
+
+    this.digest.fill(0)
+    this.chainingKey.fill(0)
+
+    this.digest = null
+    this.chainingKey = null
+    this.offset = null
+
+    this.curve = null
   }
 
   static get alg () {

--- a/test/against-ref.js
+++ b/test/against-ref.js
@@ -16,29 +16,29 @@ test('XX handshake against reference impl', t => {
   initiator.initialise(Buffer.alloc(0))
   responder.initialise(Buffer.alloc(0))
 
-  handshakeHashes.push(initiator.getHandshakeHash())
-  handshakeHashes.push(responder.getHandshakeHash())
+  const client = ref.initialize('XX', true, Buffer.alloc(0), initiator.s, initiator.e)
+  const server = ref.initialize('XX', false, Buffer.alloc(0), responder.s, responder.e)
+
+  handshakeHashes.push(initiator.handshakeHash)
+  handshakeHashes.push(responder.handshakeHash)
 
   let message = initiator.send()
   responder.recv(message)
 
-  handshakeHashes.push(initiator.getHandshakeHash())
-  handshakeHashes.push(responder.getHandshakeHash())
+  handshakeHashes.push(initiator.handshakeHash)
+  handshakeHashes.push(responder.handshakeHash)
 
   message = responder.send()
   initiator.recv(message)
 
-  handshakeHashes.push(initiator.getHandshakeHash())
-  handshakeHashes.push(responder.getHandshakeHash())
+  handshakeHashes.push(initiator.handshakeHash)
+  handshakeHashes.push(responder.handshakeHash)
 
   message = initiator.send()
   responder.recv(message)
 
-  handshakeHashes.push(initiator.getHandshakeHash())
-  handshakeHashes.push(responder.getHandshakeHash())
-
-  const client = ref.initialize('XX', true, Buffer.alloc(0), initiator.s, initiator.e)
-  const server = ref.initialize('XX', false, Buffer.alloc(0), responder.s, responder.e)
+  handshakeHashes.push(initiator.handshakeHash)
+  handshakeHashes.push(responder.handshakeHash)
 
   storeHash(client, refHandshakeHashes)
   storeHash(server, refHandshakeHashes)
@@ -70,10 +70,10 @@ test('XX handshake against reference impl', t => {
   storeHash(client, refHandshakeHashes)
   storeHash(server, refHandshakeHashes)
 
-  t.deepEqual(initiator.rx.key, splitClient.rx.subarray(0, 32))
-  t.deepEqual(initiator.tx.key, splitClient.tx.subarray(0, 32))
-  t.deepEqual(initiator.rx.key, splitServer.tx.subarray(0, 32))
-  t.deepEqual(initiator.tx.key, splitServer.rx.subarray(0, 32))
+  t.deepEqual(initiator.rx, splitClient.rx.subarray(0, 32))
+  t.deepEqual(initiator.tx, splitClient.tx.subarray(0, 32))
+  t.deepEqual(initiator.rx, splitServer.tx.subarray(0, 32))
+  t.deepEqual(initiator.tx, splitServer.rx.subarray(0, 32))
 
   while (handshakeHashes.length && refHandshakeHashes.length) {
     t.same(handshakeHashes.shift(), refHandshakeHashes.shift())
@@ -98,27 +98,27 @@ test('IK handshake against reference impl', t => {
   initiator.initialise(Buffer.alloc(0), responder.s.publicKey)
   responder.initialise(Buffer.alloc(0))
 
-  handshakeHashes.push(initiator.getHandshakeHash())
-  handshakeHashes.push(responder.getHandshakeHash())
+  const client = ref.initialize('IK', true, Buffer.alloc(0), initiator.s, initiator.e, responder.s.publicKey)
+  const server = ref.initialize('IK', false, Buffer.alloc(0), responder.s, responder.e)
+
+  handshakeHashes.push(initiator.handshakeHash)
+  handshakeHashes.push(responder.handshakeHash)
 
   while (!initiator.handshakeComplete) {
     const message = initiator.send()
     responder.recv(message)
 
-    handshakeHashes.push(initiator.getHandshakeHash())
-    handshakeHashes.push(responder.getHandshakeHash())
+    handshakeHashes.push(initiator.handshakeHash)
+    handshakeHashes.push(responder.handshakeHash)
 
     if (!responder.handshakeComplete) {
       const reply = responder.send()
       initiator.recv(reply)
 
-      handshakeHashes.push(initiator.getHandshakeHash())
-      handshakeHashes.push(responder.getHandshakeHash())
+      handshakeHashes.push(initiator.handshakeHash)
+      handshakeHashes.push(responder.handshakeHash)
     }
   }
-
-  const client = ref.initialize('IK', true, Buffer.alloc(0), initiator.s, initiator.e, responder.s.publicKey)
-  const server = ref.initialize('IK', false, Buffer.alloc(0), responder.s, responder.e)
 
   const clientTx = Buffer.alloc(512)
   const serverRx = Buffer.alloc(512)
@@ -144,10 +144,10 @@ test('IK handshake against reference impl', t => {
   storeHash(client, refHandshakeHashes)
   storeHash(server, refHandshakeHashes)
 
-  t.deepEqual(initiator.rx.key, splitClient.rx.subarray(0, 32))
-  t.deepEqual(initiator.tx.key, splitClient.tx.subarray(0, 32))
-  t.deepEqual(initiator.rx.key, splitServer.tx.subarray(0, 32))
-  t.deepEqual(initiator.tx.key, splitServer.rx.subarray(0, 32))
+  t.deepEqual(initiator.rx, splitClient.rx.subarray(0, 32))
+  t.deepEqual(initiator.tx, splitClient.tx.subarray(0, 32))
+  t.deepEqual(initiator.rx, splitServer.tx.subarray(0, 32))
+  t.deepEqual(initiator.tx, splitServer.rx.subarray(0, 32))
 
   while (handshakeHashes.length && refHandshakeHashes.length) {
     t.same(handshakeHashes.shift(), refHandshakeHashes.shift())
@@ -180,7 +180,7 @@ test('IK handshake with reference server', t => {
     splitClient = ref.readMessage(server, message, serverRx)
 
     t.same(payload, serverRx.subarray(0, ref.readMessage.bytes))
-    t.same(initiator.getHandshakeHash(), getHash(server))
+    t.same(initiator.handshakeHash, getHash(server))
 
     if (!splitClient) {
       payload = randomBytes(128)
@@ -189,12 +189,12 @@ test('IK handshake with reference server', t => {
       const check = initiator.recv(serverTx.subarray(0, ref.writeMessage.bytes))
 
       t.same(payload, check)
-      t.same(initiator.getHandshakeHash(), getHash(server))
+      t.same(initiator.handshakeHash, getHash(server))
     }
   }
 
-  t.deepEqual(initiator.rx.key, splitClient.rx.subarray(0, 32))
-  t.deepEqual(initiator.tx.key, splitClient.tx.subarray(0, 32))
+  t.deepEqual(initiator.rx, splitClient.rx.subarray(0, 32))
+  t.deepEqual(initiator.tx, splitClient.tx.subarray(0, 32))
 
   t.end()
 
@@ -224,7 +224,7 @@ test('IK handshake with reference client', t => {
     const check = responder.recv(clientTx.subarray(0, ref.writeMessage.bytes))
 
     t.same(payload, check)
-    t.same(responder.getHandshakeHash(), getHash(client))
+    t.same(responder.handshakeHash, getHash(client))
 
     if (!splitServer) {
       payload = randomBytes(128)
@@ -233,12 +233,12 @@ test('IK handshake with reference client', t => {
       splitServer = ref.readMessage(client, message, clientRx)
 
       t.same(payload, clientRx.subarray(0, ref.readMessage.bytes))
-      t.same(responder.getHandshakeHash(), getHash(client))
+      t.same(responder.handshakeHash, getHash(client))
     }
   }
 
-  t.deepEqual(responder.rx.key, splitServer.rx.subarray(0, 32))
-  t.deepEqual(responder.tx.key, splitServer.tx.subarray(0, 32))
+  t.deepEqual(responder.rx, splitServer.rx.subarray(0, 32))
+  t.deepEqual(responder.tx, splitServer.tx.subarray(0, 32))
 
   t.end()
 
@@ -268,7 +268,7 @@ test('XX handshake with reference server', t => {
     splitClient = ref.readMessage(server, message, serverRx)
 
     t.same(payload, serverRx.subarray(0, ref.readMessage.bytes))
-    t.same(initiator.getHandshakeHash(), getHash(server))
+    t.same(initiator.handshakeHash, getHash(server))
 
     if (!splitClient) {
       payload = randomBytes(128)
@@ -277,12 +277,12 @@ test('XX handshake with reference server', t => {
       const check = initiator.recv(serverTx.subarray(0, ref.writeMessage.bytes))
 
       t.same(payload, check)
-      t.same(initiator.getHandshakeHash(), getHash(server))
+      t.same(initiator.handshakeHash, getHash(server))
     }
   }
 
-  t.deepEqual(initiator.rx.key, splitClient.tx.subarray(0, 32))
-  t.deepEqual(initiator.tx.key, splitClient.rx.subarray(0, 32))
+  t.deepEqual(initiator.rx, splitClient.tx.subarray(0, 32))
+  t.deepEqual(initiator.tx, splitClient.rx.subarray(0, 32))
 
   t.end()
 
@@ -312,7 +312,7 @@ test('XX handshake with reference client', t => {
     const check = responder.recv(clientTx.subarray(0, ref.writeMessage.bytes))
 
     t.same(payload, check)
-    t.same(responder.getHandshakeHash(), getHash(client))
+    t.same(responder.handshakeHash, getHash(client))
 
     if (!splitServer) {
       payload = randomBytes(128)
@@ -321,12 +321,12 @@ test('XX handshake with reference client', t => {
       splitServer = ref.readMessage(client, message, clientRx)
 
       t.same(payload, clientRx.subarray(0, ref.readMessage.bytes))
-      t.same(responder.getHandshakeHash(), getHash(client))
+      t.same(responder.handshakeHash, getHash(client))
     }
   }
 
-  t.deepEqual(responder.rx.key, splitServer.tx.subarray(0, 32))
-  t.deepEqual(responder.tx.key, splitServer.rx.subarray(0, 32))
+  t.deepEqual(responder.rx, splitServer.tx.subarray(0, 32))
+  t.deepEqual(responder.tx, splitServer.rx.subarray(0, 32))
 
   t.end()
 

--- a/test/against-ref.js
+++ b/test/against-ref.js
@@ -16,23 +16,23 @@ test('XX handshake against reference impl', t => {
   initiator.initialise(Buffer.alloc(0))
   responder.initialise(Buffer.alloc(0))
 
-  const client = ref.initialize('XX', true, Buffer.alloc(0), initiator.s, initiator.e)
-  const server = ref.initialize('XX', false, Buffer.alloc(0), responder.s, responder.e)
-
-  handshakeHashes.push(initiator.handshakeHash)
-  handshakeHashes.push(responder.handshakeHash)
+  handshakeHashes.push(initiator.getHandshakeHash())
+  handshakeHashes.push(responder.getHandshakeHash())
 
   let message = initiator.send()
   responder.recv(message)
 
-  handshakeHashes.push(initiator.handshakeHash)
-  handshakeHashes.push(responder.handshakeHash)
+  handshakeHashes.push(initiator.getHandshakeHash())
+  handshakeHashes.push(responder.getHandshakeHash())
 
   message = responder.send()
   initiator.recv(message)
 
-  handshakeHashes.push(initiator.handshakeHash)
-  handshakeHashes.push(responder.handshakeHash)
+  handshakeHashes.push(initiator.getHandshakeHash())
+  handshakeHashes.push(responder.getHandshakeHash())
+
+  const client = ref.initialize('XX', true, Buffer.alloc(0), clone(initiator.s), clone(initiator.e))
+  const server = ref.initialize('XX', false, Buffer.alloc(0), clone(responder.s), clone(responder.e))
 
   message = initiator.send()
   responder.recv(message)
@@ -98,27 +98,25 @@ test('IK handshake against reference impl', t => {
   initiator.initialise(Buffer.alloc(0), responder.s.publicKey)
   responder.initialise(Buffer.alloc(0))
 
-  const client = ref.initialize('IK', true, Buffer.alloc(0), initiator.s, initiator.e, responder.s.publicKey)
-  const server = ref.initialize('IK', false, Buffer.alloc(0), responder.s, responder.e)
+  handshakeHashes.push(initiator.getHandshakeHash())
+  handshakeHashes.push(responder.getHandshakeHash())
+
+  const message = initiator.send()
+  responder.recv(message)
+
+  handshakeHashes.push(initiator.getHandshakeHash())
+  handshakeHashes.push(responder.getHandshakeHash())
+
+  responder.e = generateKeyPair()
+
+  const server = ref.initialize('IK', false, Buffer.alloc(0), clone(responder.s), clone(responder.e))
+  const client = ref.initialize('IK', true, Buffer.alloc(0), clone(initiator.s), clone(initiator.e), clone(responder.s).publicKey)
+
+  const reply = responder.send()
+  initiator.recv(reply)
 
   handshakeHashes.push(initiator.handshakeHash)
   handshakeHashes.push(responder.handshakeHash)
-
-  while (!initiator.handshakeComplete) {
-    const message = initiator.send()
-    responder.recv(message)
-
-    handshakeHashes.push(initiator.handshakeHash)
-    handshakeHashes.push(responder.handshakeHash)
-
-    if (!responder.handshakeComplete) {
-      const reply = responder.send()
-      initiator.recv(reply)
-
-      handshakeHashes.push(initiator.handshakeHash)
-      handshakeHashes.push(responder.handshakeHash)
-    }
-  }
 
   const clientTx = Buffer.alloc(512)
   const serverRx = Buffer.alloc(512)
@@ -173,25 +171,21 @@ test('IK handshake with reference server', t => {
 
   let splitClient
 
-  while (!initiator.handshakeComplete) {
-    let payload = randomBytes(128)
+  let payload = randomBytes(128)
 
-    const message = initiator.send(payload)
-    splitClient = ref.readMessage(server, message, serverRx)
+  const message = initiator.send(payload)
+  splitClient = ref.readMessage(server, message, serverRx)
 
-    t.same(payload, serverRx.subarray(0, ref.readMessage.bytes))
-    t.same(initiator.handshakeHash, getHash(server))
+  t.same(payload, serverRx.subarray(0, ref.readMessage.bytes))
+  t.same(initiator.getHandshakeHash(), getHash(server))
 
-    if (!splitClient) {
-      payload = randomBytes(128)
+  payload = randomBytes(128)
 
-      splitClient = ref.writeMessage(server, payload, serverTx)
-      const check = initiator.recv(serverTx.subarray(0, ref.writeMessage.bytes))
+  splitClient = ref.writeMessage(server, payload, serverTx)
+  const check = initiator.recv(serverTx.subarray(0, ref.writeMessage.bytes))
 
-      t.same(payload, check)
-      t.same(initiator.handshakeHash, getHash(server))
-    }
-  }
+  t.same(payload, check)
+  t.same(initiator.handshakeHash, getHash(server))
 
   t.deepEqual(initiator.rx, splitClient.rx.subarray(0, 32))
   t.deepEqual(initiator.tx, splitClient.tx.subarray(0, 32))
@@ -217,25 +211,21 @@ test('IK handshake with reference client', t => {
 
   let splitServer
 
-  while (!responder.handshakeComplete) {
-    let payload = randomBytes(128)
+  let payload = randomBytes(128)
 
-    splitServer = ref.writeMessage(client, payload, clientTx)
-    const check = responder.recv(clientTx.subarray(0, ref.writeMessage.bytes))
+  splitServer = ref.writeMessage(client, payload, clientTx)
+  const check = responder.recv(clientTx.subarray(0, ref.writeMessage.bytes))
 
-    t.same(payload, check)
-    t.same(responder.handshakeHash, getHash(client))
+  t.same(payload, check)
+  t.same(responder.getHandshakeHash(), getHash(client))
 
-    if (!splitServer) {
-      payload = randomBytes(128)
+  payload = randomBytes(128)
 
-      const message = responder.send(payload)
-      splitServer = ref.readMessage(client, message, clientRx)
+  const message = responder.send(payload)
+  splitServer = ref.readMessage(client, message, clientRx)
 
-      t.same(payload, clientRx.subarray(0, ref.readMessage.bytes))
-      t.same(responder.handshakeHash, getHash(client))
-    }
-  }
+  t.same(payload, clientRx.subarray(0, ref.readMessage.bytes))
+  t.same(responder.handshakeHash, getHash(client))
 
   t.deepEqual(responder.rx, splitServer.rx.subarray(0, 32))
   t.deepEqual(responder.tx, splitServer.tx.subarray(0, 32))
@@ -261,25 +251,27 @@ test('XX handshake with reference server', t => {
 
   let splitClient
 
-  while (!initiator.handshakeComplete) {
-    let payload = randomBytes(128)
+  let payload = randomBytes(128)
 
-    const message = initiator.send(payload)
-    splitClient = ref.readMessage(server, message, serverRx)
+  let message = initiator.send(payload)
+  splitClient = ref.readMessage(server, message, serverRx)
 
-    t.same(payload, serverRx.subarray(0, ref.readMessage.bytes))
-    t.same(initiator.handshakeHash, getHash(server))
+  t.same(payload, serverRx.subarray(0, ref.readMessage.bytes))
+  t.same(initiator.getHandshakeHash(), getHash(server))
 
-    if (!splitClient) {
-      payload = randomBytes(128)
+  payload = randomBytes(128)
 
-      splitClient = ref.writeMessage(server, payload, serverTx)
-      const check = initiator.recv(serverTx.subarray(0, ref.writeMessage.bytes))
+  splitClient = ref.writeMessage(server, payload, serverTx)
+  const check = initiator.recv(serverTx.subarray(0, ref.writeMessage.bytes))
 
-      t.same(payload, check)
-      t.same(initiator.handshakeHash, getHash(server))
-    }
-  }
+  t.same(payload, check)
+  t.same(initiator.getHandshakeHash(), getHash(server))
+
+  message = initiator.send(payload)
+  splitClient = ref.readMessage(server, message, serverRx)
+
+  t.same(payload, serverRx.subarray(0, ref.readMessage.bytes))
+  t.same(initiator.handshakeHash, getHash(server))
 
   t.deepEqual(initiator.rx, splitClient.tx.subarray(0, 32))
   t.deepEqual(initiator.tx, splitClient.rx.subarray(0, 32))
@@ -305,25 +297,29 @@ test('XX handshake with reference client', t => {
 
   let splitServer
 
-  while (!responder.handshakeComplete) {
-    let payload = randomBytes(128)
+  let payload = randomBytes(128)
 
-    splitServer = ref.writeMessage(client, payload, clientTx)
-    const check = responder.recv(clientTx.subarray(0, ref.writeMessage.bytes))
+  splitServer = ref.writeMessage(client, payload, clientTx)
+  let check = responder.recv(clientTx.subarray(0, ref.writeMessage.bytes))
 
-    t.same(payload, check)
-    t.same(responder.handshakeHash, getHash(client))
+  t.same(payload, check)
+  t.same(responder.getHandshakeHash(), getHash(client))
 
-    if (!splitServer) {
-      payload = randomBytes(128)
+  payload = randomBytes(128)
 
-      const message = responder.send(payload)
-      splitServer = ref.readMessage(client, message, clientRx)
+  const message = responder.send(payload)
+  splitServer = ref.readMessage(client, message, clientRx)
 
-      t.same(payload, clientRx.subarray(0, ref.readMessage.bytes))
-      t.same(responder.handshakeHash, getHash(client))
-    }
-  }
+  t.same(payload, clientRx.subarray(0, ref.readMessage.bytes))
+  t.same(responder.getHandshakeHash(), getHash(client))
+
+  payload = randomBytes(128)
+
+  splitServer = ref.writeMessage(client, payload, clientTx)
+  check = responder.recv(clientTx.subarray(0, ref.writeMessage.bytes))
+
+  t.same(payload, check)
+  t.same(responder.handshakeHash, getHash(client))
 
   t.deepEqual(responder.rx, splitServer.tx.subarray(0, 32))
   t.deepEqual(responder.tx, splitServer.rx.subarray(0, 32))
@@ -341,4 +337,12 @@ function randomBytes (n) {
   const bytes = Buffer.alloc(Math.ceil(Math.random() * n))
   sodium.randombytes_buf(bytes)
   return bytes
+}
+
+function clone (key = {}) {
+  if (!key) return {}
+  return {
+    secretKey: key.secretKey ? Buffer.from(key.secretKey) : null,
+    publicKey: key.publicKey ? Buffer.from(key.publicKey) : null
+  }
 }

--- a/test/handshake.js
+++ b/test/handshake.js
@@ -5,21 +5,30 @@ test('IK', t => {
   const initiator = new NoiseState('IK', true)
   const responder = new NoiseState('IK', false)
 
+  const rpk = new Uint8Array(responder.s.publicKey)
   initiator.initialise(Buffer.alloc(0), responder.s.publicKey)
   responder.initialise(Buffer.alloc(0))
 
-  while (!initiator.handshakeComplete) {
-    const message = initiator.send()
-    responder.recv(message)
+  const message = initiator.send()
+  responder.recv(message)
 
-    if (!responder.handshakeComplete) {
-      const reply = responder.send()
-      initiator.recv(reply)
-    }
-  }
+  const reply = responder.send()
+  initiator.recv(reply)
 
-  t.deepEqual(initiator.rx.key, responder.tx.key)
-  t.deepEqual(initiator.tx.key, responder.rx.key)
+  t.equal(initiator.key, null)
+  t.equal(initiator.nonce, null)
+  t.equal(initiator.curve, null)
+  t.equal(initiator.digest, null)
+  t.equal(initiator.chainingKey, null)
+  t.equal(initiator.offset, null)
+  t.equal(initiator.e, null)
+  t.equal(initiator.re, null)
+  t.equal(initiator.rs, null)
+
+  t.same(initiator.remotePublicKey, rpk)
+
+  t.deepEqual(initiator.rx, responder.tx)
+  t.deepEqual(initiator.tx, responder.rx)
   t.end()
 })
 
@@ -40,7 +49,7 @@ test('XX', t => {
     }
   }
 
-  t.deepEqual(initiator.rx.key, responder.tx.key)
-  t.deepEqual(initiator.tx.key, responder.rx.key)
+  t.deepEqual(initiator.rx, responder.tx)
+  t.deepEqual(initiator.tx, responder.rx)
   t.end()
 })

--- a/test/payload.js
+++ b/test/payload.js
@@ -17,8 +17,8 @@ test('IK with payload', t => {
   message = responder.send(payload2)
   t.deepEqual(initiator.recv(message), payload2)
 
-  t.deepEqual(initiator.rx.key, responder.tx.key)
-  t.deepEqual(initiator.tx.key, responder.rx.key)
+  t.deepEqual(initiator.rx, responder.tx)
+  t.deepEqual(initiator.tx, responder.rx)
   t.end()
 })
 
@@ -42,7 +42,7 @@ test('XX with payload', t => {
   message = initiator.send(payload3)
   t.deepEqual(responder.recv(message), payload3)
 
-  t.deepEqual(initiator.rx.key, responder.tx.key)
-  t.deepEqual(initiator.tx.key, responder.rx.key)
+  t.deepEqual(initiator.rx, responder.tx)
+  t.deepEqual(initiator.tx, responder.rx)
   t.end()
 })


### PR DESCRIPTION
This PR implements:
- clean up handshake state after completion
- finalised handshake returns session keys as opposed to ciphers