### PR TITLE
Clear state after handshake is complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Send the next message in the handshake, add an optional payload buffer to be inc
 
 Receive a handshake message from the peer and return the encrypted payload.
 
-#### `peer.handshakeComplete`
+#### `peer.complete`
 
 `true` or `false`. Indicates whether `rx` and `tx` have been created yet.
 
@@ -78,6 +78,6 @@ When complete, the working handshake state shall be cleared *only* the following
   tx, // session key to decrypt messages from remote peer
   rx, // session key to encrypt messages to remote peer
   rs, // the remote peer's public key,
-  handshakeHash, // a hash of the entire handshake state
+  hash, // a hash of the entire handshake state
 }
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 ## Usage
 ```js
-const Noise = require('basic-noise')
+const Noise = require('noise-handshake')
+const Cipher = require('noise-handshake/cipher')
 const initiator = new Noise('IK ', true)
 const responder = new Noise('IK', false)
 
@@ -22,10 +23,14 @@ initiator.recv(reply)
 
 console.log(initiator.handshakeComplete) // true
 
+// instantiate a cipher using shared secrets
+const send = new Cipher(initiator.rx)
+const recieve = new Cipher(initiator.tx)
+
 const msg = Buffer.from('hello, world')
 
-const enc = initiator.rx.encrypt(msg)
-console.log(responder.tx.decrypt(enc)) // hello, world
+const enc = send.encrypt(msg)
+console.log(recieve.decrypt(enc)) // hello, world
 ```
 
 ## API
@@ -66,10 +71,13 @@ Receive a handshake message from the peer and return the encrypted payload.
 
 `true` or `false`. Indicates whether `rx` and `tx` have been created yet.
 
-#### `const ciphertext = peer.rx.encrypt(plaintext, [ad])`
+When complete, the working handshake state shall be cleared *only* the following state shall remain on the object:
 
-Encrypt a message to the remote peer with an optional authenticated data passed in as `ad`.
-
-#### `const plaintext = peer.tx.decrypt(ciphertext, [ad])`
-
-Decrypt a ciphertext from the remote peer. Note `initiator.rx` is decrypted by `responder.tx` and vice versa. If the message was encrypted with authenticated data, this must be passed in as `ad` otherwise decryption shall fail
+```js
+{
+  tx, // session key to decrypt messages from remote peer
+  rx, // session key to encrypt messages to remote peer
+  remotePublicKey, // the remote peers public key,
+  handshakeHash, // a hash of the entire handshake state
+}
+```

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ When complete, the working handshake state shall be cleared *only* the following
 {
   tx, // session key to decrypt messages from remote peer
   rx, // session key to encrypt messages to remote peer
-  remotePublicKey, // the remote peers public key,
+  rs, // the remote peer's public key,
   handshakeHash, // a hash of the entire handshake state
 }
 ```

--- a/cipher.js
+++ b/cipher.js
@@ -40,6 +40,12 @@ module.exports = class CipherState {
     return this.key !== null
   }
 
+  _clear () {
+    this.key.fill(0)
+    this.key = null
+    this.nonce = null
+  }
+
   static get MACBYTES () {
     return 16
   }

--- a/cipher.js
+++ b/cipher.js
@@ -41,7 +41,7 @@ module.exports = class CipherState {
   }
 
   _clear () {
-    this.key.fill(0)
+    sodium.sodium_memzero(this.key)
     this.key = null
     this.nonce = null
   }

--- a/noise.js
+++ b/noise.js
@@ -93,6 +93,7 @@ module.exports = class NoiseState extends SymmetricState {
 
     this.rx = null
     this.tx = null
+    this.handshakeHash = null
   }
 
   initialise (prologue, remoteStatic) {
@@ -125,12 +126,15 @@ module.exports = class NoiseState extends SymmetricState {
   }
 
   final () {
-    const { cipher1, cipher2 } = this.split()
+    const [k1, k2] = this.split()
 
-    this.tx = this.initiator ? cipher1 : cipher2
-    this.rx = this.initiator ? cipher2 : cipher1
+    this.tx = this.initiator ? k1 : k2
+    this.rx = this.initiator ? k2 : k1
 
     this.handshakeComplete = true
+    this.handshakeHash = this.getHandshakeHash()
+
+    // this._clear()
   }
 
   recv (buf) {
@@ -210,6 +214,18 @@ module.exports = class NoiseState extends SymmetricState {
 
     if (!this.handshake.length) this.final()
     return w.end()
+  }
+
+  _clear () {
+    super._clear()
+
+    this.e.secretKey.fill(0)
+    this.re.fill(0)
+    this.rs.fill(0)
+
+    this.e.secretKey = null
+    this.re = null
+    this.rs = null
   }
 }
 

--- a/noise.js
+++ b/noise.js
@@ -134,7 +134,9 @@ module.exports = class NoiseState extends SymmetricState {
     this.handshakeComplete = true
     this.handshakeHash = this.getHandshakeHash()
 
-    // this._clear()
+    this.remotePublicKey = new Uint8Array(this.rs)
+
+    this._clear()
   }
 
   recv (buf) {
@@ -211,19 +213,22 @@ module.exports = class NoiseState extends SymmetricState {
     }
 
     w.push(this.encryptAndHash(payload))
+    const response = w.end()
 
     if (!this.handshake.length) this.final()
-    return w.end()
+    return response
   }
 
   _clear () {
     super._clear()
 
     this.e.secretKey.fill(0)
+    this.e.publicKey.fill(0)
+
     this.re.fill(0)
     this.rs.fill(0)
 
-    this.e.secretKey = null
+    this.e = null
     this.re = null
     this.rs = null
   }

--- a/noise.js
+++ b/noise.js
@@ -89,11 +89,11 @@ module.exports = class NoiseState extends SymmetricState {
     ].join('_'))
 
     this.initiator = initiator
-    this.handshakeComplete = false
+    this.complete = false
 
     this.rx = null
     this.tx = null
-    this.handshakeHash = null
+    this.hash = null
   }
 
   initialise (prologue, remoteStatic) {
@@ -131,8 +131,8 @@ module.exports = class NoiseState extends SymmetricState {
     this.tx = this.initiator ? k1 : k2
     this.rx = this.initiator ? k2 : k1
 
-    this.handshakeComplete = true
-    this.handshakeHash = this.getHandshakeHash()
+    this.complete = true
+    this.hash = this.getHandshakeHash()
 
     this._clear()
   }

--- a/noise.js
+++ b/noise.js
@@ -134,8 +134,6 @@ module.exports = class NoiseState extends SymmetricState {
     this.handshakeComplete = true
     this.handshakeHash = this.getHandshakeHash()
 
-    this.remotePublicKey = new Uint8Array(this.rs)
-
     this._clear()
   }
 
@@ -226,11 +224,9 @@ module.exports = class NoiseState extends SymmetricState {
     this.e.publicKey.fill(0)
 
     this.re.fill(0)
-    this.rs.fill(0)
 
     this.e = null
     this.re = null
-    this.rs = null
   }
 }
 

--- a/symmetric-state.js
+++ b/symmetric-state.js
@@ -48,12 +48,21 @@ module.exports = class SymmetricState extends CipherState {
   }
 
   split () {
-    const [k1, k2] = hkdf(this.chainingKey, Buffer.alloc(0))
+    const res = hkdf(this.chainingKey, Buffer.alloc(0))
+    return res.map(k => k.subarray(0, 32))
+  }
 
-    return {
-      cipher1: new CipherState(k1.subarray(0, 32)),
-      cipher2: new CipherState(k2.subarray(0, 32))
-    }
+  _clear () {
+    super._clear()
+
+    this.digest.fill(0)
+    this.chainingKey.fill(0)
+
+    this.digest = null
+    this.chainingKey = null
+    this.offset = null
+
+    this.curve = null
   }
 
   static get alg () {

--- a/symmetric-state.js
+++ b/symmetric-state.js
@@ -55,8 +55,8 @@ module.exports = class SymmetricState extends CipherState {
   _clear () {
     super._clear()
 
-    this.digest.fill(0)
-    this.chainingKey.fill(0)
+    sodium.sodium_memzero(this.digest)
+    sodium.sodium_memzero(this.chainingKey)
 
     this.digest = null
     this.chainingKey = null

--- a/test/against-ref.js
+++ b/test/against-ref.js
@@ -16,29 +16,29 @@ test('XX handshake against reference impl', t => {
   initiator.initialise(Buffer.alloc(0))
   responder.initialise(Buffer.alloc(0))
 
-  handshakeHashes.push(initiator.getHandshakeHash())
-  handshakeHashes.push(responder.getHandshakeHash())
+  const client = ref.initialize('XX', true, Buffer.alloc(0), initiator.s, initiator.e)
+  const server = ref.initialize('XX', false, Buffer.alloc(0), responder.s, responder.e)
+
+  handshakeHashes.push(initiator.handshakeHash)
+  handshakeHashes.push(responder.handshakeHash)
 
   let message = initiator.send()
   responder.recv(message)
 
-  handshakeHashes.push(initiator.getHandshakeHash())
-  handshakeHashes.push(responder.getHandshakeHash())
+  handshakeHashes.push(initiator.handshakeHash)
+  handshakeHashes.push(responder.handshakeHash)
 
   message = responder.send()
   initiator.recv(message)
 
-  handshakeHashes.push(initiator.getHandshakeHash())
-  handshakeHashes.push(responder.getHandshakeHash())
+  handshakeHashes.push(initiator.handshakeHash)
+  handshakeHashes.push(responder.handshakeHash)
 
   message = initiator.send()
   responder.recv(message)
 
-  handshakeHashes.push(initiator.getHandshakeHash())
-  handshakeHashes.push(responder.getHandshakeHash())
-
-  const client = ref.initialize('XX', true, Buffer.alloc(0), initiator.s, initiator.e)
-  const server = ref.initialize('XX', false, Buffer.alloc(0), responder.s, responder.e)
+  handshakeHashes.push(initiator.handshakeHash)
+  handshakeHashes.push(responder.handshakeHash)
 
   storeHash(client, refHandshakeHashes)
   storeHash(server, refHandshakeHashes)
@@ -70,10 +70,10 @@ test('XX handshake against reference impl', t => {
   storeHash(client, refHandshakeHashes)
   storeHash(server, refHandshakeHashes)
 
-  t.deepEqual(initiator.rx.key, splitClient.rx.subarray(0, 32))
-  t.deepEqual(initiator.tx.key, splitClient.tx.subarray(0, 32))
-  t.deepEqual(initiator.rx.key, splitServer.tx.subarray(0, 32))
-  t.deepEqual(initiator.tx.key, splitServer.rx.subarray(0, 32))
+  t.deepEqual(initiator.rx, splitClient.rx.subarray(0, 32))
+  t.deepEqual(initiator.tx, splitClient.tx.subarray(0, 32))
+  t.deepEqual(initiator.rx, splitServer.tx.subarray(0, 32))
+  t.deepEqual(initiator.tx, splitServer.rx.subarray(0, 32))
 
   while (handshakeHashes.length && refHandshakeHashes.length) {
     t.same(handshakeHashes.shift(), refHandshakeHashes.shift())
@@ -98,27 +98,27 @@ test('IK handshake against reference impl', t => {
   initiator.initialise(Buffer.alloc(0), responder.s.publicKey)
   responder.initialise(Buffer.alloc(0))
 
-  handshakeHashes.push(initiator.getHandshakeHash())
-  handshakeHashes.push(responder.getHandshakeHash())
+  const client = ref.initialize('IK', true, Buffer.alloc(0), initiator.s, initiator.e, responder.s.publicKey)
+  const server = ref.initialize('IK', false, Buffer.alloc(0), responder.s, responder.e)
+
+  handshakeHashes.push(initiator.handshakeHash)
+  handshakeHashes.push(responder.handshakeHash)
 
   while (!initiator.handshakeComplete) {
     const message = initiator.send()
     responder.recv(message)
 
-    handshakeHashes.push(initiator.getHandshakeHash())
-    handshakeHashes.push(responder.getHandshakeHash())
+    handshakeHashes.push(initiator.handshakeHash)
+    handshakeHashes.push(responder.handshakeHash)
 
     if (!responder.handshakeComplete) {
       const reply = responder.send()
       initiator.recv(reply)
 
-      handshakeHashes.push(initiator.getHandshakeHash())
-      handshakeHashes.push(responder.getHandshakeHash())
+      handshakeHashes.push(initiator.handshakeHash)
+      handshakeHashes.push(responder.handshakeHash)
     }
   }
-
-  const client = ref.initialize('IK', true, Buffer.alloc(0), initiator.s, initiator.e, responder.s.publicKey)
-  const server = ref.initialize('IK', false, Buffer.alloc(0), responder.s, responder.e)
 
   const clientTx = Buffer.alloc(512)
   const serverRx = Buffer.alloc(512)
@@ -144,10 +144,10 @@ test('IK handshake against reference impl', t => {
   storeHash(client, refHandshakeHashes)
   storeHash(server, refHandshakeHashes)
 
-  t.deepEqual(initiator.rx.key, splitClient.rx.subarray(0, 32))
-  t.deepEqual(initiator.tx.key, splitClient.tx.subarray(0, 32))
-  t.deepEqual(initiator.rx.key, splitServer.tx.subarray(0, 32))
-  t.deepEqual(initiator.tx.key, splitServer.rx.subarray(0, 32))
+  t.deepEqual(initiator.rx, splitClient.rx.subarray(0, 32))
+  t.deepEqual(initiator.tx, splitClient.tx.subarray(0, 32))
+  t.deepEqual(initiator.rx, splitServer.tx.subarray(0, 32))
+  t.deepEqual(initiator.tx, splitServer.rx.subarray(0, 32))
 
   while (handshakeHashes.length && refHandshakeHashes.length) {
     t.same(handshakeHashes.shift(), refHandshakeHashes.shift())
@@ -180,7 +180,7 @@ test('IK handshake with reference server', t => {
     splitClient = ref.readMessage(server, message, serverRx)
 
     t.same(payload, serverRx.subarray(0, ref.readMessage.bytes))
-    t.same(initiator.getHandshakeHash(), getHash(server))
+    t.same(initiator.handshakeHash, getHash(server))
 
     if (!splitClient) {
       payload = randomBytes(128)
@@ -189,12 +189,12 @@ test('IK handshake with reference server', t => {
       const check = initiator.recv(serverTx.subarray(0, ref.writeMessage.bytes))
 
       t.same(payload, check)
-      t.same(initiator.getHandshakeHash(), getHash(server))
+      t.same(initiator.handshakeHash, getHash(server))
     }
   }
 
-  t.deepEqual(initiator.rx.key, splitClient.rx.subarray(0, 32))
-  t.deepEqual(initiator.tx.key, splitClient.tx.subarray(0, 32))
+  t.deepEqual(initiator.rx, splitClient.rx.subarray(0, 32))
+  t.deepEqual(initiator.tx, splitClient.tx.subarray(0, 32))
 
   t.end()
 
@@ -224,7 +224,7 @@ test('IK handshake with reference client', t => {
     const check = responder.recv(clientTx.subarray(0, ref.writeMessage.bytes))
 
     t.same(payload, check)
-    t.same(responder.getHandshakeHash(), getHash(client))
+    t.same(responder.handshakeHash, getHash(client))
 
     if (!splitServer) {
       payload = randomBytes(128)
@@ -233,12 +233,12 @@ test('IK handshake with reference client', t => {
       splitServer = ref.readMessage(client, message, clientRx)
 
       t.same(payload, clientRx.subarray(0, ref.readMessage.bytes))
-      t.same(responder.getHandshakeHash(), getHash(client))
+      t.same(responder.handshakeHash, getHash(client))
     }
   }
 
-  t.deepEqual(responder.rx.key, splitServer.rx.subarray(0, 32))
-  t.deepEqual(responder.tx.key, splitServer.tx.subarray(0, 32))
+  t.deepEqual(responder.rx, splitServer.rx.subarray(0, 32))
+  t.deepEqual(responder.tx, splitServer.tx.subarray(0, 32))
 
   t.end()
 
@@ -268,7 +268,7 @@ test('XX handshake with reference server', t => {
     splitClient = ref.readMessage(server, message, serverRx)
 
     t.same(payload, serverRx.subarray(0, ref.readMessage.bytes))
-    t.same(initiator.getHandshakeHash(), getHash(server))
+    t.same(initiator.handshakeHash, getHash(server))
 
     if (!splitClient) {
       payload = randomBytes(128)
@@ -277,12 +277,12 @@ test('XX handshake with reference server', t => {
       const check = initiator.recv(serverTx.subarray(0, ref.writeMessage.bytes))
 
       t.same(payload, check)
-      t.same(initiator.getHandshakeHash(), getHash(server))
+      t.same(initiator.handshakeHash, getHash(server))
     }
   }
 
-  t.deepEqual(initiator.rx.key, splitClient.tx.subarray(0, 32))
-  t.deepEqual(initiator.tx.key, splitClient.rx.subarray(0, 32))
+  t.deepEqual(initiator.rx, splitClient.tx.subarray(0, 32))
+  t.deepEqual(initiator.tx, splitClient.rx.subarray(0, 32))
 
   t.end()
 
@@ -312,7 +312,7 @@ test('XX handshake with reference client', t => {
     const check = responder.recv(clientTx.subarray(0, ref.writeMessage.bytes))
 
     t.same(payload, check)
-    t.same(responder.getHandshakeHash(), getHash(client))
+    t.same(responder.handshakeHash, getHash(client))
 
     if (!splitServer) {
       payload = randomBytes(128)
@@ -321,12 +321,12 @@ test('XX handshake with reference client', t => {
       splitServer = ref.readMessage(client, message, clientRx)
 
       t.same(payload, clientRx.subarray(0, ref.readMessage.bytes))
-      t.same(responder.getHandshakeHash(), getHash(client))
+      t.same(responder.handshakeHash, getHash(client))
     }
   }
 
-  t.deepEqual(responder.rx.key, splitServer.tx.subarray(0, 32))
-  t.deepEqual(responder.tx.key, splitServer.rx.subarray(0, 32))
+  t.deepEqual(responder.rx, splitServer.tx.subarray(0, 32))
+  t.deepEqual(responder.tx, splitServer.rx.subarray(0, 32))
 
   t.end()
 

--- a/test/against-ref.js
+++ b/test/against-ref.js
@@ -9,7 +9,7 @@ test('XX handshake against reference impl', t => {
   const initiator = new Noise('XX', true)
   const responder = new Noise('XX', false)
 
-  const handshakeHash = Buffer.alloc(64)
+  const hash = Buffer.alloc(64)
   const handshakeHashes = []
   const refHandshakeHashes = []
 
@@ -37,8 +37,8 @@ test('XX handshake against reference impl', t => {
   message = initiator.send()
   responder.recv(message)
 
-  handshakeHashes.push(initiator.handshakeHash)
-  handshakeHashes.push(responder.handshakeHash)
+  handshakeHashes.push(initiator.hash)
+  handshakeHashes.push(responder.hash)
 
   storeHash(client, refHandshakeHashes)
   storeHash(server, refHandshakeHashes)
@@ -82,8 +82,8 @@ test('XX handshake against reference impl', t => {
   t.end()
 
   function storeHash (state, arr) {
-    getHandshakeHash(state.symmetricState, handshakeHash)
-    arr.push(Buffer.from(handshakeHash))
+    getHandshakeHash(state.symmetricState, hash)
+    arr.push(Buffer.from(hash))
   }
 })
 
@@ -91,7 +91,7 @@ test('IK handshake against reference impl', t => {
   const initiator = new Noise('IK', true)
   const responder = new Noise('IK', false)
 
-  const handshakeHash = Buffer.alloc(64)
+  const hash = Buffer.alloc(64)
   const handshakeHashes = []
   const refHandshakeHashes = []
 
@@ -115,8 +115,8 @@ test('IK handshake against reference impl', t => {
   const reply = responder.send()
   initiator.recv(reply)
 
-  handshakeHashes.push(initiator.handshakeHash)
-  handshakeHashes.push(responder.handshakeHash)
+  handshakeHashes.push(initiator.hash)
+  handshakeHashes.push(responder.hash)
 
   const clientTx = Buffer.alloc(512)
   const serverRx = Buffer.alloc(512)
@@ -154,8 +154,8 @@ test('IK handshake against reference impl', t => {
   t.end()
 
   function storeHash (state, arr) {
-    getHandshakeHash(state.symmetricState, handshakeHash)
-    arr.push(Buffer.from(handshakeHash))
+    getHandshakeHash(state.symmetricState, hash)
+    arr.push(Buffer.from(hash))
   }
 })
 
@@ -185,7 +185,7 @@ test('IK handshake with reference server', t => {
   const check = initiator.recv(serverTx.subarray(0, ref.writeMessage.bytes))
 
   t.same(payload, check)
-  t.same(initiator.handshakeHash, getHash(server))
+  t.same(initiator.hash, getHash(server))
 
   t.deepEqual(initiator.rx, splitClient.rx.subarray(0, 32))
   t.deepEqual(initiator.tx, splitClient.tx.subarray(0, 32))
@@ -225,7 +225,7 @@ test('IK handshake with reference client', t => {
   splitServer = ref.readMessage(client, message, clientRx)
 
   t.same(payload, clientRx.subarray(0, ref.readMessage.bytes))
-  t.same(responder.handshakeHash, getHash(client))
+  t.same(responder.hash, getHash(client))
 
   t.deepEqual(responder.rx, splitServer.rx.subarray(0, 32))
   t.deepEqual(responder.tx, splitServer.tx.subarray(0, 32))
@@ -271,7 +271,7 @@ test('XX handshake with reference server', t => {
   splitClient = ref.readMessage(server, message, serverRx)
 
   t.same(payload, serverRx.subarray(0, ref.readMessage.bytes))
-  t.same(initiator.handshakeHash, getHash(server))
+  t.same(initiator.hash, getHash(server))
 
   t.deepEqual(initiator.rx, splitClient.tx.subarray(0, 32))
   t.deepEqual(initiator.tx, splitClient.rx.subarray(0, 32))
@@ -319,7 +319,7 @@ test('XX handshake with reference client', t => {
   check = responder.recv(clientTx.subarray(0, ref.writeMessage.bytes))
 
   t.same(payload, check)
-  t.same(responder.handshakeHash, getHash(client))
+  t.same(responder.hash, getHash(client))
 
   t.deepEqual(responder.rx, splitServer.tx.subarray(0, 32))
   t.deepEqual(responder.tx, splitServer.rx.subarray(0, 32))
@@ -369,7 +369,7 @@ test('Bugfix: prologue >64 bytes', t => {
   check = responder.recv(clientTx.subarray(0, ref.writeMessage.bytes))
 
   t.same(payload, check)
-  t.same(responder.handshakeHash, getHash(client))
+  t.same(responder.hash, getHash(client))
 
   t.deepEqual(responder.rx, splitServer.tx.subarray(0, 32))
   t.deepEqual(responder.tx, splitServer.rx.subarray(0, 32))

--- a/test/handshake.js
+++ b/test/handshake.js
@@ -5,21 +5,30 @@ test('IK', t => {
   const initiator = new NoiseState('IK', true)
   const responder = new NoiseState('IK', false)
 
+  const rpk = new Uint8Array(responder.s.publicKey)
   initiator.initialise(Buffer.alloc(0), responder.s.publicKey)
   responder.initialise(Buffer.alloc(0))
 
-  while (!initiator.handshakeComplete) {
-    const message = initiator.send()
-    responder.recv(message)
+  const message = initiator.send()
+  responder.recv(message)
 
-    if (!responder.handshakeComplete) {
-      const reply = responder.send()
-      initiator.recv(reply)
-    }
-  }
+  const reply = responder.send()
+  initiator.recv(reply)
 
-  t.deepEqual(initiator.rx.key, responder.tx.key)
-  t.deepEqual(initiator.tx.key, responder.rx.key)
+  t.equal(initiator.key, null)
+  t.equal(initiator.nonce, null)
+  t.equal(initiator.curve, null)
+  t.equal(initiator.digest, null)
+  t.equal(initiator.chainingKey, null)
+  t.equal(initiator.offset, null)
+  t.equal(initiator.e, null)
+  t.equal(initiator.re, null)
+  t.equal(initiator.rs, null)
+
+  t.same(initiator.remotePublicKey, rpk)
+
+  t.deepEqual(initiator.rx, responder.tx)
+  t.deepEqual(initiator.tx, responder.rx)
   t.end()
 })
 
@@ -40,7 +49,7 @@ test('XX', t => {
     }
   }
 
-  t.deepEqual(initiator.rx.key, responder.tx.key)
-  t.deepEqual(initiator.tx.key, responder.rx.key)
+  t.deepEqual(initiator.rx, responder.tx)
+  t.deepEqual(initiator.tx, responder.rx)
   t.end()
 })

--- a/test/handshake.js
+++ b/test/handshake.js
@@ -23,9 +23,8 @@ test('IK', t => {
   t.equal(initiator.offset, null)
   t.equal(initiator.e, null)
   t.equal(initiator.re, null)
-  t.equal(initiator.rs, null)
 
-  t.same(initiator.remotePublicKey, rpk)
+  t.same(initiator.rs, rpk)
 
   t.deepEqual(initiator.rx, responder.tx)
   t.deepEqual(initiator.tx, responder.rx)

--- a/test/handshake.js
+++ b/test/handshake.js
@@ -5,7 +5,7 @@ test('IK', t => {
   const initiator = new NoiseState('IK', true)
   const responder = new NoiseState('IK', false)
 
-  const rpk = new Uint8Array(responder.s.publicKey)
+  const rpk = Buffer.from(responder.s.publicKey)
   initiator.initialise(Buffer.alloc(0), responder.s.publicKey)
   responder.initialise(Buffer.alloc(0))
 
@@ -38,15 +38,11 @@ test('XX', t => {
   initiator.initialise(Buffer.alloc(0))
   responder.initialise(Buffer.alloc(0))
 
-  while (!initiator.handshakeComplete) {
-    const message = initiator.send()
-    responder.recv(message)
+  const message = initiator.send()
+  responder.recv(message)
 
-    if (!responder.handshakeComplete) {
-      const reply = responder.send()
-      initiator.recv(reply)
-    }
-  }
+  const reply = responder.send()
+  initiator.recv(reply)
 
   t.deepEqual(initiator.rx, responder.tx)
   t.deepEqual(initiator.tx, responder.rx)

--- a/test/payload.js
+++ b/test/payload.js
@@ -17,8 +17,8 @@ test('IK with payload', t => {
   message = responder.send(payload2)
   t.deepEqual(initiator.recv(message), payload2)
 
-  t.deepEqual(initiator.rx.key, responder.tx.key)
-  t.deepEqual(initiator.tx.key, responder.rx.key)
+  t.deepEqual(initiator.rx, responder.tx)
+  t.deepEqual(initiator.tx, responder.rx)
   t.end()
 })
 
@@ -42,7 +42,7 @@ test('XX with payload', t => {
   message = initiator.send(payload3)
   t.deepEqual(responder.recv(message), payload3)
 
-  t.deepEqual(initiator.rx.key, responder.tx.key)
-  t.deepEqual(initiator.tx.key, responder.rx.key)
+  t.deepEqual(initiator.rx, responder.tx)
+  t.deepEqual(initiator.tx, responder.rx)
   t.end()
 })


### PR DESCRIPTION
This PR implements:
- clean up handshake state after completion
- finalised handshake returns session keys as opposed to ciphers