### PR TITLE
Handle tweaked keys

### DIFF
--- a/dh.js
+++ b/dh.js
@@ -48,16 +48,16 @@ function generateSeedKeyPair (seed) {
   return keyPair
 }
 
-function dh (pk, lsk) {
-  assert(lsk.byteLength === SKLEN)
-  assert(pk.byteLength === PKLEN)
+function dh (publicKey, { secretKey }) {
+  assert(secretKey.byteLength === SKLEN)
+  assert(publicKey.byteLength === PKLEN)
 
   const output = b4a.alloc(DHLEN)
 
   crypto_scalarmult(
     output,
-    lsk,
-    pk
+    secretKey,
+    publicKey
   )
 
   return output

--- a/noise.js
+++ b/noise.js
@@ -160,7 +160,7 @@ module.exports = class NoiseState extends SymmetricState {
         case TOK_SS : {
           const useStatic = keyPattern(pattern, this.initiator)
 
-          const localKey = useStatic.local ? this.s.secretKey : this.e.secretKey
+          const localKey = useStatic.local ? this.s : this.e
           const remoteKey = useStatic.remote ? this.rs : this.re
 
           this.mixKey(remoteKey, localKey)
@@ -199,7 +199,7 @@ module.exports = class NoiseState extends SymmetricState {
         case TOK_SS : {
           const useStatic = keyPattern(pattern, this.initiator)
 
-          const localKey = useStatic.local ? this.s.secretKey : this.e.secretKey
+          const localKey = useStatic.local ? this.s : this.e
           const remoteKey = useStatic.remote ? this.rs : this.re
 
           this.mixKey(remoteKey, localKey)

--- a/symmetric-state.js
+++ b/symmetric-state.js
@@ -21,8 +21,8 @@ module.exports = class SymmetricState extends CipherState {
     accumulateDigest(this.digest, data)
   }
 
-  mixKey (pubkey, seckey) {
-    const dh = this.curve.dh(pubkey, seckey)
+  mixKey (remoteKey, localKey) {
+    const dh = this.curve.dh(remoteKey, localKey)
     const hkdfResult = hkdf(this.chainingKey, dh)
     this.chainingKey = hkdfResult[0]
     this.initialiseKey(hkdfResult[1].subarray(0, 32))


### PR DESCRIPTION
For tweaked ed25519 keyPairs, `scalar` is passed directly instead of `secretKey`.

In order to handle this case, we pass the entire keyPair object to `curve.dh`.