### PR TITLE
inline hmac to use the same allocation everywhere

### DIFF
--- a/hkdf.js
+++ b/hkdf.js
@@ -1,5 +1,5 @@
+const hmacBlake2b = require('./hmac')
 const assert = require('nanoassert')
-const hmacBlake2b = require('hmac-blake2b')
 const b4a = require('b4a')
 
 const HASHLEN = 64

--- a/hmac.js
+++ b/hmac.js
@@ -1,0 +1,39 @@
+/* eslint-disable camelcase */
+const b4a = require('b4a')
+const { sodium_memzero } = require('sodium-universal/memory')
+const { crypto_generichash, crypto_generichash_batch } = require('sodium-universal/crypto_generichash')
+
+const HASHLEN = 64
+const BLOCKLEN = 128
+const scratch = b4a.alloc(BLOCKLEN * 3)
+const HMACKey = scratch.subarray(BLOCKLEN * 0, BLOCKLEN * 1)
+const OuterKeyPad = scratch.subarray(BLOCKLEN * 1, BLOCKLEN * 2)
+const InnerKeyPad = scratch.subarray(BLOCKLEN * 2, BLOCKLEN * 3)
+
+// Post-fill is done in the cases where someone caught an exception that
+// happened before we were able to clear data at the end
+
+module.exports = function hmac (out, data, key) {
+  if (key.byteLength > BLOCKLEN) {
+    crypto_generichash(HMACKey.subarray(0, HASHLEN), key)
+    sodium_memzero(HMACKey.subarray(HASHLEN))
+  } else {
+    // Covers key <= BLOCKLEN
+    HMACKey.set(key)
+    sodium_memzero(HMACKey.subarray(key.byteLength))
+  }
+
+  for (let i = 0; i < HMACKey.byteLength; i++) {
+    OuterKeyPad[i] = 0x5c ^ HMACKey[i]
+    InnerKeyPad[i] = 0x36 ^ HMACKey[i]
+  }
+  sodium_memzero(HMACKey)
+
+  crypto_generichash_batch(out, [InnerKeyPad].concat(data))
+  sodium_memzero(InnerKeyPad)
+  crypto_generichash_batch(out, [OuterKeyPad].concat(out))
+  sodium_memzero(OuterKeyPad)
+}
+
+module.exports.BYTES = HASHLEN
+module.exports.KEYBYTES = BLOCKLEN

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   },
   "dependencies": {
     "b4a": "^1.1.0",
-    "hmac-blake2b": "^2.0.0",
     "nanoassert": "^2.0.0",
     "sodium-universal": "^3.0.4"
   },


### PR DESCRIPTION
I inlined hmac, as the npm version doesn't run on latest electron and I don't have access to fix it. Can you verify?